### PR TITLE
removeReadableUser 関数を追加。

### DIFF
--- a/functions/spec/memoFunctions.spec.ts
+++ b/functions/spec/memoFunctions.spec.ts
@@ -54,7 +54,6 @@ describe('memo functions', () => {
   }
 
   const data = {
-    requesterId: 'rabbit',
     memoId: 'alice-memo',
     memoAuthorId: 'alice',
   }

--- a/functions/src/memoFunctions.ts
+++ b/functions/src/memoFunctions.ts
@@ -6,10 +6,10 @@ admin.initializeApp({
 })
 const firestore = admin.firestore();
 
-export const addReadableUser = functions.https.onRequest(async (request, response) => {
-  const memoId = request.query.memoId as string
-  const memoAuthorId = request.query.memoAuthorId as string
-  const requesterId = request.query.requesterId as string
+export const addReadableUser = functions.https.onCall(async (data, context) => {
+  const memoId = data.memoId as string
+  const memoAuthorId = data.memoAuthorId as string
+  const requesterId = data.requesterId as string
 
   const memoReference = await firestore.collection('users').doc(memoAuthorId).collection('memos').doc(memoId);
   const requesterReference = await firestore.collection('users').doc(requesterId);
@@ -20,5 +20,5 @@ export const addReadableUser = functions.https.onRequest(async (request, respons
     readable_users: memo.get('readable_users').concat([requesterReference])
   })
 
-  response.send('ok');
+  return 'ok'
 });

--- a/functions/src/memoFunctions.ts
+++ b/functions/src/memoFunctions.ts
@@ -9,7 +9,7 @@ const firestore = admin.firestore();
 export const addReadableUser = functions.https.onCall(async (data, context) => {
   const memoId = data.memoId as string
   const memoAuthorId = data.memoAuthorId as string
-  const requesterId = data.requesterId as string
+  const requesterId = context.auth?.uid as string
 
   const memoReference = await firestore.collection('users').doc(memoAuthorId).collection('memos').doc(memoId);
   const requesterReference = await firestore.collection('users').doc(requesterId);


### PR DESCRIPTION
## removeReadableUser 関数
引数
```
memoId: string,
memoAuthorId: string,
removedUserId: string
```

返り値
```
return 'ok'
return 'permission denied'
```

この関数は，メモの作成者，または削除対象が自身の時，実行することができます。
それ以外のユーザーが実行した場合は，'permission denied'を返し，何も変更はありません。
