### PR TITLE
TypeScriptの命名規則に従うためのリファクタリング

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,7 @@ service cloud.firestore {
     match /users/{userId}/memos/{memoId} {
       allow read, write, update, delete: if request.auth.uid == userId;
       allow read: if (
-        /databases/$(database)/documents/users/$(request.auth.uid) in resource.data.readable_users
+        /databases/$(database)/documents/users/$(request.auth.uid) in resource.data.readableUsers
       )
     }
   }

--- a/functions/spec/memoFunctions.spec.ts
+++ b/functions/spec/memoFunctions.spec.ts
@@ -28,7 +28,7 @@ describe('memo functions', () => {
 
     await aliceReference.collection('memos').doc('alice-memo').set({
       content: '',
-      readable_users: []
+      readableUsers: []
     });
   })
 
@@ -68,7 +68,7 @@ describe('memo functions', () => {
 
       await addReadableUser.run(mockReq(requestData), mockRes(context));
 
-      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readable_users
+      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readableUsers
       expect(readableUsers[0].isEqual(rabbitReference)).toBeTruthy;
       done();
     })
@@ -88,7 +88,7 @@ describe('memo functions', () => {
     it('remove from readable users if the requester is the author', async (done) => {
       await removeReadableUser.run(mockReq(data), mockRes({ auth: { uid: 'alice' } }));
 
-      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readable_users
+      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readableUsers
       expect(readableUsers).toBeFalsy;
       done();      
     })
@@ -96,7 +96,7 @@ describe('memo functions', () => {
     it('remove if the requester is the removed user', async (done) => {
       await removeReadableUser.run(mockReq(data), mockRes({ auth: { uid: 'rabbit' }}))
 
-      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readable_users
+      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readableUsers
       expect(readableUsers).toBeFalsy;
       done();
     })
@@ -104,7 +104,7 @@ describe('memo functions', () => {
     it("don't remove in other cases", async (done) => {
       await removeReadableUser.run(mockReq(data), mockRes({ auth: { uid: 'cat' }}))
 
-      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readable_users
+      const readableUsers = (await aliceReference.collection('memos').doc('alice-memo').get()).data()!.readableUsers
       expect(readableUsers[0].isEqual(rabbitReference)).toBeTruthy
       done();
     })

--- a/functions/spec/memoRules.spec.ts
+++ b/functions/spec/memoRules.spec.ts
@@ -61,10 +61,10 @@ describe('firestore rules', () => {
         await firebase.assertSucceeds(memo.get());
       })
 
-      test('who is in a readable_users can read the memo', async () => {
+      test('who is in a readableUsers can read the memo', async () => {
         await memo.set({
           content: 'memo!',
-          readable_users: [humpty.collection('users').doc('Humpty Dumpty')]
+          readableUsers: [humpty.collection('users').doc('Humpty Dumpty')]
         });
 
         await firebase.assertSucceeds(
@@ -72,7 +72,7 @@ describe('firestore rules', () => {
         );
       });
 
-      test('who is not in a readable_users cannot read the memo', async () => {
+      test('who is not in a readableUsers cannot read the memo', async () => {
         await memo.set({ content: 'memo!' });
         await firebase.assertFails(
           king.collection('users').doc('Humpty Dumpty').collection('memos').doc('0').get()

--- a/functions/spec/userRules.spec.ts
+++ b/functions/spec/userRules.spec.ts
@@ -35,33 +35,33 @@ describe('firestore rules', () => {
   }
 
   describe("user rules", () => {
-    const alice_client = newFirebaseApp({uid: 'alice'});
+    const aliceClient = newFirebaseApp({uid: 'alice'});
 
     describe('write', () => {
       test('users can write the user document', async () => {
-        const alice_profile = alice_client.collection('users').doc('alice');
+        const aliceProfile = aliceClient.collection('users').doc('alice');
 
-        await firebase.assertSucceeds(alice_profile.set({'name': 'alice'}))
+        await firebase.assertSucceeds(aliceProfile.set({'name': 'alice'}))
       })
 
       test('users cannot write other user documents', async () => {
-        const rabbit_profile = alice_client.collection('users').doc('rabbit');
+        const rabbitProfile = aliceClient.collection('users').doc('rabbit');
 
-        await firebase.assertFails(rabbit_profile.set({'name': 'rabbit'}));
+        await firebase.assertFails(rabbitProfile.set({'name': 'rabbit'}));
       })
     })
 
     describe('read', () => {
       test('authed user can read all user documents', async () => {
-        alice_client.collection('users').doc('alice').set({'name': 'alice'});
-        const rabbit_client = newFirebaseApp({uid: 'rabbit'});
-        const alice_profile = rabbit_client.collection('users').doc('alice');
+        aliceClient.collection('users').doc('alice').set({'name': 'alice'});
+        const rabbitClient = newFirebaseApp({uid: 'rabbit'});
+        const aliceProfile = rabbitClient.collection('users').doc('alice');
 
-        await firebase.assertSucceeds(alice_profile.get());
+        await firebase.assertSucceeds(aliceProfile.get());
       })
 
       test('not authed user cannot read all user documents', async () => {
-        alice_client.collection('users').doc('alice').set({'name': 'alice'});
+        aliceClient.collection('users').doc('alice').set({'name': 'alice'});
         const notAuthedClient = firebase.initializeTestApp({ projectId: projectId }).firestore();
 
         await firebase.assertFails(
@@ -71,41 +71,41 @@ describe('firestore rules', () => {
     });
 
     describe('update', () => {
-      const alice_profile = alice_client.collection('users').doc('alice');
+      const aliceProfile = aliceClient.collection('users').doc('alice');
 
       test('users can update the user document', async () => {
-        alice_profile.set({'name': 'alice'});
+        aliceProfile.set({'name': 'alice'});
 
         await firebase.assertSucceeds(
-          alice_client.collection('users').doc('alice').update({'name': 'alice'})
+          aliceClient.collection('users').doc('alice').update({'name': 'alice'})
         );
       })
 
       test('users cannot update other user document', async () => {
-        alice_profile.set({'name': 'alice'});
+        aliceProfile.set({'name': 'alice'});
 
-        const rabbit_client = newFirebaseApp({ uid: 'rabbit' });
+        const rabbitClient = newFirebaseApp({ uid: 'rabbit' });
         await firebase.assertFails(
-          rabbit_client.collection('users').doc('alice').update({'name': 'new alice'})
+          rabbitClient.collection('users').doc('alice').update({'name': 'new alice'})
         );
       })
     });
 
     describe('delete', () => {
-      const alice_profile = alice_client.collection('users').doc('alice');
+      const aliceProfile = aliceClient.collection('users').doc('alice');
 
       test('users can delete the user document', async () => {
-        alice_profile.set({'name': 'alice'});
+        aliceProfile.set({'name': 'alice'});
 
-        await firebase.assertSucceeds(alice_profile.delete());
+        await firebase.assertSucceeds(aliceProfile.delete());
       })
 
       test('users cannot delete other user documents', async () => {
-        alice_profile.set({'name': 'alice'});
+        aliceProfile.set({'name': 'alice'});
 
-        const rabbit_client = newFirebaseApp({ uid: 'rabbit' });
+        const rabbitClient = newFirebaseApp({ uid: 'rabbit' });
         await firebase.assertFails(
-          rabbit_client.collection('users').doc('alice').delete()
+          rabbitClient.collection('users').doc('alice').delete()
         );
       })
     });

--- a/functions/src/memoFunctions.ts
+++ b/functions/src/memoFunctions.ts
@@ -17,7 +17,7 @@ export const addReadableUser = functions.https.onCall(async (data, context) => {
   const memo = await memoReference.get();
 
   await memoReference.update({
-    readable_users: memo.get('readable_users').concat([requesterReference])
+    readableUsers: memo.get('readableUsers').concat([requesterReference])
   })
 
   return 'ok'
@@ -38,7 +38,7 @@ export const removeReadableUser = functions.https.onCall(async (data, context) =
   const memo = await memoReference.get();
 
   await memoReference.update({
-    readable_users: memo.get('readable_users').filter(
+    readableUsers: memo.get('readableUsers').filter(
       (user: FirebaseFirestore.DocumentReference) => user.isEqual(removedUserReference)
     )
   })


### PR DESCRIPTION
## した事
スネークケースが含まれていたので，キャメルケースに直した。

## 重大な変更
`readable_users` を `readableUsers` に変更された点に気をつけてください。
